### PR TITLE
ParsedCommandFactory#build does not check validity of input string

### DIFF
--- a/src/main/java/br/com/caelum/vraptor/console/command/parser/ParsedCommandFactory.java
+++ b/src/main/java/br/com/caelum/vraptor/console/command/parser/ParsedCommandFactory.java
@@ -9,6 +9,9 @@ public class ParsedCommandFactory {
 	public ParsedCommand build(String cmd) {
 		String[] args = cmd.split("\\s+");
 		LinkedList<String> argsList = new LinkedList<>(asList(args));
+		if (argsList.size() < 1) {
+		        throw new IllegalArgumentException("Command was not passed");
+		}
 		String commandName = argsList.removeFirst();
 		return new ParsedCommand(commandName, argsList);
 	}

--- a/src/test/java/br/com/caelum/vraptor/console/command/parser/ParsedCommandFactoryTest.java
+++ b/src/test/java/br/com/caelum/vraptor/console/command/parser/ParsedCommandFactoryTest.java
@@ -15,4 +15,10 @@ public class ParsedCommandFactoryTest extends ParsedCommandFactory {
 		assertEquals("command", cmd.getCommandName());
 	}
 
+
+        @Test(expected = IllegalArgumentException.class)
+        public void should_throw_exception_from_empty_string() {
+	        ParsedCommandFactory factory = new ParsedCommandFactory();
+		ParsedCommand cmd = factory.build(" ");
+         }
 }


### PR DESCRIPTION
In `ParsedCommandFactory.java`, the number of elements in the `argList` is not checked before removing the first element from the list.  There is an assumption that the input string passed for parsing will always be valid, leading to runtime exceptions with no good error message when the string is empty. This pull request adds a potential fix and a test for this issue.
